### PR TITLE
implement _write()

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -80,7 +80,7 @@ class RTCStream extends Duplex {
     }
 
     _write(chunk: any, encoding: BufferEncoding, callback: WriteCallback): void {
-        this._writev([{chunk, encoding}], callback);
+        this._writev([{ chunk, encoding }], callback);
     }
 
     _writev(chunks: { chunk: any, encoding: BufferEncoding }[], callback: WriteCallback): void {

--- a/index.ts
+++ b/index.ts
@@ -79,7 +79,7 @@ class RTCStream extends Duplex {
     _read(size: number): void {
     }
 
-    _write( chunk: any, encoding: BufferEncoding, callback: WriteCallback): void {
+    _write(chunk: any, encoding: BufferEncoding, callback: WriteCallback): void {
         this._writev([{chunk, encoding}], callback);
     }
 

--- a/index.ts
+++ b/index.ts
@@ -79,6 +79,10 @@ class RTCStream extends Duplex {
     _read(size: number): void {
     }
 
+    _write( chunk: any, encoding: BufferEncoding, callback: WriteCallback): void {
+        this._writev([{chunk, encoding}], callback);
+    }
+
     _writev(chunks: { chunk: any, encoding: BufferEncoding }[], callback: WriteCallback): void {
         this.#pendingWriteBuffer = Buffer.concat(chunks.map(({ chunk }) => (typeof chunk === "string") ? Buffer.from(chunk, "utf8") : chunk));
         this.#pendingWriteCallback = callback;


### PR DESCRIPTION
Even if `_writev()` is implemented, it appears that `_write()` is not optional:

https://nodejs.org/api/stream.html#stream_writable_write_chunk_encoding_callback_1
https://github.com/nodejs/node/issues/28408#issuecomment-510093107

I ran into this when testing `@frida/web-client` in the browser, compiled with rollup. I did need to use `vite-compatible-readable-stream`  instead of `readable-stream` due to rollup circular dependency issues: https://github.com/nodejs/readable-stream/issues/348#issuecomment-855231224. At runtime I was getting errors about `_write`.

This commit implements `_write()` in terms of `_writev()`. I think this is appropriate, and is very simple to implement this way.